### PR TITLE
Do reverse url lookup for get_login_redirect_url

### DIFF
--- a/oauthlogin/providers.py
+++ b/oauthlogin/providers.py
@@ -179,13 +179,14 @@ class OAuthProvider:
         auth_login(request=request, user=user, backend=self.authentication_backend)
 
     def get_login_redirect_url(self, *, request: HttpRequest) -> str:
-        url = request.session.pop(SESSION_NEXT_KEY, settings.LOGIN_REDIRECT_URL)
         try:
-            # If this is a named URL pattern, we need to `reverse` it
-            return reverse(url)
+            # The LOGIN_REDIRECT_URL setting can be a named URL
+            # which we need to reverse
+            default_redirect_url = reverse(settings.LOGIN_REDIRECT_URL)
         except NoReverseMatch:
-            # Assuming the url isn't a named url
-            return url
+            default_redirect_url = settings.LOGIN_REDIRECT_URL
+
+        return request.session.pop(SESSION_NEXT_KEY, default_redirect_url)
 
     def get_disconnect_redirect_url(self, *, request: HttpRequest) -> str:
         return request.POST.get("next", "/")

--- a/oauthlogin/providers.py
+++ b/oauthlogin/providers.py
@@ -6,7 +6,7 @@ from urllib.parse import urlencode
 from django.conf import settings
 from django.contrib.auth import login as auth_login
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
-from django.urls import reverse, NoReverseMatch
+from django.urls import NoReverseMatch, reverse
 from django.utils.crypto import get_random_string
 from django.utils.module_loading import import_string
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -494,3 +494,18 @@ def test_dummy_refresh(settings, monkeypatch):
     assert connection.refresh_token_expires_at == datetime.datetime(
         2029, 1, 2, 0, 0, tzinfo=datetime.timezone.utc
     )
+
+
+def test_login_redirect_urls(client, settings):
+    provider = DummyProvider(
+        provider_key="",
+        client_id="",
+        client_secret="",
+    )
+    request = client.get("/").wsgi_request
+
+    assert provider.get_login_redirect_url(request=request) == "/"
+
+    settings.LOGIN_REDIRECT_URL = "home"
+
+    assert provider.get_login_redirect_url(request=request) == "/home/"

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import LogoutView
 from django.urls import include, path
+from django.views import View
 from django.views.generic import TemplateView
 
 from oauthlogin.providers import get_provider_keys
@@ -20,10 +21,15 @@ class LoginView(TemplateView):
     template_name = "login.html"
 
 
+class HomeView(View):
+    pass
+
+
 urlpatterns = [
     path("admin", admin.site.urls),
     path("oauth/", include("oauthlogin.urls")),
     path("login/", LoginView.as_view(), name="login"),
     path("logout/", LogoutView.as_view(), name="logout"),
+    path("home/", HomeView.as_view(), name="home"),
     path("", LoggedInView.as_view()),
 ]


### PR DESCRIPTION
According to the [documentation](https://docs.djangoproject.com/en/4.1/ref/settings/#std-setting-LOGIN_REDIRECT_URL), `LOGIN_REDIRECT_URL` is:

> The URL or named URL pattern where requests are redirected after login when the `LoginView` doesn’t get a `next` GET parameter.

This change attempts to add support for the named URL pattern.

Unfortunately, I don't know a good way to recognise whether a URL is a "real" URL or a named URL pattern, so I'm asking for forgiveness instead of looking before I leap...